### PR TITLE
Switch to bring your own uuid for hazard creation and updates, bundle…

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,8 +29,9 @@
     "test": "LOG_LEVEL=CRITICAL DENO_TEST=1 deno test --allow-env --allow-sys --allow-read --allow-write --allow-net test/",
     "start": "deno task ensure-pre-commit-hooks && deno run --allow-env --allow-sys --allow-read --allow-write --allow-net src/server.ts",
     "watch": "deno task ensure-pre-commit-hooks && deno run --watch --allow-env --allow-sys --allow-read --allow-write --allow-net src/server.ts",
-    "db:deps": "deno cache -r --node-modules-dir drizzle.config.ts",
+    "db:deps": "deno cache --node-modules-dir drizzle.config.ts",
     "db:generate": "deno task db:deps && deno run -A --node-modules-dir npm:drizzle-kit generate",
+    "db:drop": "deno task db:deps && deno run -A --node-modules-dir npm:drizzle-kit drop",
     "db:migrate": "deno task db:deps && deno run -A --node-modules-dir npm:drizzle-kit migrate",
     "ensure-pre-commit-hooks": "deno run --allow-env --allow-sys --allow-read --allow-run .pre-commit-install.ts"
   },

--- a/drizzle/testing/0001_minor_wallop.sql
+++ b/drizzle/testing/0001_minor_wallop.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "hazards" ADD COLUMN "offline" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "updates" ADD COLUMN "offline" boolean DEFAULT false NOT NULL;

--- a/drizzle/testing/meta/0001_snapshot.json
+++ b/drizzle/testing/meta/0001_snapshot.json
@@ -1,0 +1,139 @@
+{
+  "id": "a9aaeb13-5806-4b63-8a6e-32f89ab9ccfd",
+  "prevId": "1192aeae-f24b-4e41-9bce-55f345785bf7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.hazards": {
+      "name": "hazards",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazard": {
+          "name": "hazard",
+          "type": "hazardType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail": {
+          "name": "trail",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node": {
+          "name": "node",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long": {
+          "name": "long",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.updates": {
+      "name": "updates",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazard": {
+          "name": "hazard",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blur_hash": {
+          "name": "blur_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.hazardType": {
+      "name": "hazardType",
+      "schema": "public",
+      "values": [
+        "tree",
+        "flood",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/testing/meta/_journal.json
+++ b/drizzle/testing/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1720742560424,
       "tag": "0000_eager_leper_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1721099509835,
+      "tag": "0001_minor_wallop",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -20,6 +20,7 @@ export const hazards = pgTable("hazards", {
   node: integer("node").notNull(),
   lat: doublePrecision("lat").notNull(),
   long: doublePrecision("long").notNull(),
+  offline: boolean("offline").default(false).notNull(),
 });
 
 export const updates = pgTable("updates", {
@@ -29,4 +30,5 @@ export const updates = pgTable("updates", {
   active: boolean("active").notNull(),
   blurHash: text("blur_hash"),
   image: uuid("image"),
+  offline: boolean("offline").default(false).notNull(),
 });

--- a/src/model/hazard.ts
+++ b/src/model/hazard.ts
@@ -1,5 +1,5 @@
 import { hazards, updates } from "../database/schema.ts";
-import { Hazard } from "../schema/hazard.ts";
+import { Hazard, HazardNewBodySchema } from "../schema/hazard.ts";
 
 export type HazardRow = typeof hazards.$inferInsert;
 export type HazardType = typeof hazards.$inferInsert.hazard;
@@ -12,10 +12,10 @@ export function hazardToHazardRow({ location, ...rest }: Hazard): HazardRow {
 export function hazardRowToHazard(
   { trail, node, lat, long, ...rest }: HazardRow,
 ): Hazard {
-  return {
+  return HazardNewBodySchema.parse({
     ...rest,
     location: { trail, node, lat, long },
-  };
+  });
 }
 
 export type HazardUpdateRow = typeof updates.$inferInsert;

--- a/src/route/hazard.ts
+++ b/src/route/hazard.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { v1 as uuidv1 } from "@std/uuid";
 import * as decorators from "../decorator.ts";
 import dbService from "../service/db_service.ts";
 import trailsService from "../service/trails_service.ts";
@@ -16,11 +15,8 @@ import {
 
 const server = new OpenAPIHono()
   .openapi(hazardUpdateRoute, async (ctx) => {
-    const update = {
-      ...ctx.req.valid("json"),
-      uuid: uuidv1.generate(),
-      time: new Date(),
-    };
+    const update = ctx.req.valid("json");
+    update.offline = false;
     // check that the associated hazard actually exists
     if ((await dbService.fetchHazard(update.hazard)) == null) {
       return decorators.notFound(ctx);
@@ -29,17 +25,20 @@ const server = new OpenAPIHono()
     return ctx.json(update, 200);
   })
   .openapi(hazardNewRoute, async (ctx) => {
-    const hazard = {
-      ...ctx.req.valid("json"),
-      uuid: uuidv1.generate(),
-      time: new Date(),
-    };
+    const hazard = ctx.req.valid("json");
+    hazard.offline = false;
     // check that the associated trail actually exists
     if (!trailsService.trails.has(hazard.location.trail)) {
-      return decorators.notFound(ctx);
+      return decorators.notFound(
+        ctx,
+        `Trail ${hazard.location.trail} not found!`,
+      );
     }
-    await dbService.saveHazard(hazard);
-    return ctx.json(hazard, 200);
+    if (await dbService.fetchHazard(hazard.uuid)) {
+      return decorators.conflict(ctx);
+    }
+    const update = await dbService.saveHazard(hazard);
+    return ctx.json({ hazard, updates: [update] }, 200);
   })
   .openapi(hazardActiveRoute, async (ctx) => {
     const hazards = await dbService.fetchHazards(true);
@@ -49,7 +48,7 @@ const server = new OpenAPIHono()
     const { uuid } = ctx.req.valid("param");
     const { file } = ctx.req.valid("form");
     if (await imageService.imageExists(uuid)) {
-      return decorators.conflict(ctx, "Image already exists.");
+      return decorators.conflict(ctx, "Image already exists!");
     } else {
       await imageService.saveImage(file, uuid);
       return ctx.body(null, 200);
@@ -60,7 +59,7 @@ const server = new OpenAPIHono()
     if (!await imageService.imageExists(uuid)) {
       return decorators.notFound(
         ctx,
-        `Could not find image with uuid '${uuid}'.`,
+        `Could not find image with uuid '${uuid}'!`,
       );
     }
     const reader = await imageService.getImage(uuid);

--- a/src/schema/hazard.ts
+++ b/src/schema/hazard.ts
@@ -2,16 +2,14 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { ConflictSchema, NotFoundSchema } from "../decorator.ts";
 import { hazardTypeEnum } from "../database/schema.ts";
 
-export const HazardUpdateBodySchema = z.object({
+export const HazardUpdateSchema = z.object({
   hazard: z.string().uuid(),
   active: z.boolean(),
+  uuid: z.string().uuid(),
+  time: z.coerce.date(),
   blurHash: z.string().nullish(),
   image: z.string().uuid().nullish(),
-});
-
-export const HazardUpdateSchema = HazardUpdateBodySchema.extend({
-  uuid: z.string().uuid(),
-  time: z.date(),
+  offline: z.boolean().default(false),
 });
 
 export type HazardUpdate = z.infer<typeof HazardUpdateSchema>;
@@ -25,7 +23,7 @@ export const hazardUpdateRoute = createRoute({
     body: {
       content: {
         "application/json": {
-          schema: HazardUpdateBodySchema,
+          schema: HazardUpdateSchema,
         },
       },
     },
@@ -58,16 +56,19 @@ export const HazardNewBodySchema = z.object({
     lat: z.number(),
     long: z.number(),
   }),
+  uuid: z.string().uuid(),
+  time: z.coerce.date(),
   blurHash: z.string().nullish(),
   image: z.string().uuid().nullish(),
+  offline: z.boolean().default(false),
 });
 
-export const HazardNewSchema = HazardNewBodySchema.merge(z.object({
-  uuid: z.string().uuid(),
-  time: z.date(),
-}));
+export type Hazard = z.infer<typeof HazardNewBodySchema>;
 
-export type Hazard = z.infer<typeof HazardNewSchema>;
+export const HazardNewSchema = z.object({
+  hazard: HazardNewBodySchema,
+  updates: HazardUpdateSchema.array(),
+});
 
 export const hazardNewRoute = createRoute({
   summary: "Creates a new hazard",
@@ -93,17 +94,25 @@ export const hazardNewRoute = createRoute({
       },
     },
     404: {
-      description: "Hazard with given uuid not found",
+      description: "Trail with given ID not found",
       content: {
         "application/json": {
           schema: NotFoundSchema,
         },
       },
     },
+    409: {
+      description: "Hazard with given uuid already exists",
+      content: {
+        "application/json": {
+          schema: ConflictSchema,
+        },
+      },
+    },
   },
 });
 
-export const HazardActiveSchema = HazardNewSchema.array();
+export const HazardActiveSchema = HazardNewBodySchema.array();
 
 export const hazardActiveRoute = createRoute({
   summary: "Get all active hazards",

--- a/src/service/db_service.ts
+++ b/src/service/db_service.ts
@@ -10,22 +10,25 @@ import imageService from "../service/image_service.ts";
 import { Hazard, HazardUpdate } from "../schema/hazard.ts";
 
 export class DbService {
-  async saveHazard(hazard: Hazard) {
+  async saveHazard(hazard: Hazard): Promise<HazardUpdate> {
+    const update = {
+      uuid: uuidv1.generate(),
+      hazard: hazard.uuid,
+      time: hazard.time,
+      active: true,
+      offline: false,
+      blurHash: hazard.blurHash,
+      image: hazard.image,
+    };
     const row = hazardToHazardRow(hazard);
     await db.transaction(async (tx) => {
       await db.insert(hazardsTable).values(row).onConflictDoUpdate({
         target: hazardsTable.uuid,
         set: row,
       });
-      await this.updateHazard({
-        uuid: uuidv1.generate(),
-        hazard: hazard.uuid,
-        time: hazard.time,
-        active: true,
-        blurHash: hazard.blurHash,
-        image: hazard.image,
-      }, tx);
+      await this.updateHazard(update, tx);
     });
+    return update;
   }
   async updateHazard(update: HazardUpdate, tx = db) {
     await tx.insert(updatesTable).values(update).onConflictDoUpdate({

--- a/test/routes/hazard_test.ts
+++ b/test/routes/hazard_test.ts
@@ -36,7 +36,7 @@ Deno.test(
     assertEquals(await res.json(), {
       code: NotFoundSchema.shape.code.value,
       error: NotFoundSchema.shape.error.value,
-      message: `Could not find image with uuid '${uuid}'.`,
+      message: `Could not find image with uuid '${uuid}'!`,
     });
   },
 );


### PR DESCRIPTION
Switches to bring your own uuid for hazard creation and updates. This allows storing local copies of hazard objects in client cache while offline.

Bundles hazard/new hazard and updates together to reduce the number of requests required - helps in low network environment

Closes #4 